### PR TITLE
Adds the missing concat() definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 export class ExtendedIterable<T> implements Iterable<T> {
+	concat(secondIterable: Iterable<T>): ExtendedIterable<T>;
 	new(sourceArray: Iterable<T>): ExtendedIterable<T>;
 	map<U>(callback: (entry: T, index: number) => U): ExtendedIterable<U>
 	flatMap<U>(callback: (entry: T, index: number) => U[]): ExtendedIterable<U>


### PR DESCRIPTION
Missing the definition for `concat()`.